### PR TITLE
Automatically determine compatible Ruby versions

### DIFF
--- a/.github/workflows/test-gem.yml
+++ b/.github/workflows/test-gem.yml
@@ -4,11 +4,6 @@ name: Test
 on:
   workflow_call:
     inputs:
-      ruby:
-        description: Ruby versions to use, written as a JSON string"
-        default: '["2.7"]'
-        required: false
-        type: string
       working-directory:
         description: The working directory where all jobs should be executed
         default: '.'
@@ -21,13 +16,23 @@ on:
         type: string
 
 jobs:
+  setup_matrix:
+    name: "Determine Ruby versions"
+    runs-on: ubuntu-latest
+    outputs:
+      ruby: ${{ steps.ruby.outputs.versions }}
+    steps:
+      - id: ruby
+        uses: ekohl/ruby-version@v0
+
   test:
     name: "Ruby ${{ matrix.ruby }}"
     runs-on: ubuntu-latest
+    needs: setup_matrix
     strategy:
       fail-fast: false
       matrix:
-        ruby: ${{ fromJSON(inputs.ruby) }}
+        ruby: ${{ fromJSON(needs.setup_matrix.outputs.ruby) }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup ruby


### PR DESCRIPTION
This uses the `required_ruby_version` field in the gemspec to determine the testing matrix, rather than specifying it as a parameter.