### PR TITLE
Fix the chapter to release a gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,10 @@ To release a gem, use the following workflow
 name: Release
 
 on:
-  create:
-    ref_type: tag
+  push:
+    # Pattern matched against refs/tags
+    tags:
+      - '**'
 
 jobs:
   release:


### PR DESCRIPTION
The previous behavior did not work and the action was started for branches, too. The new implementation starts the github action for pushed tags-