### PR TITLE
Add dummy jobs to dynamic matrix workflows

### DIFF
--- a/.github/workflows/foreman_plugin.yml
+++ b/.github/workflows/foreman_plugin.yml
@@ -179,6 +179,14 @@ jobs:
           path: log/*.log
           retention-days: 5
 
+  # A dummy job that you can mark as a required check instead of each individual test
+  test-suite:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Test suite
+    steps:
+      - run: echo Test suite completed
+
   existing-database:
     name: "Existing database - Foreman ${{ inputs.foreman_version }} with Ruby ${{ matrix.ruby }} and Node ${{ matrix.node }} on PostgreSQL ${{ matrix.postgresql }}"
     if: ${{ inputs.test_existing_database }}
@@ -239,3 +247,11 @@ jobs:
         run: |
           bundle exec rake db:migrate
           bundle exec rake db:seed
+
+  # A dummy job that you can mark as a required check instead of each individual test
+  existing-database-suite:
+    needs: existing-database
+    runs-on: ubuntu-latest
+    name: Existing database suite
+    steps:
+      - run: echo Test suite completed

--- a/.github/workflows/foreman_plugin_js.yml
+++ b/.github/workflows/foreman_plugin_js.yml
@@ -127,3 +127,11 @@ jobs:
       - name: Run ${{ inputs.plugin }} tests
         run: npm test
         working-directory: ${{ inputs.plugin }}
+
+  # A dummy job that you can mark as a required check instead of each individual test
+  test-suite:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Test suite
+    steps:
+      - run: echo Test suite completed

--- a/.github/workflows/test-gem.yml
+++ b/.github/workflows/test-gem.yml
@@ -50,3 +50,11 @@ jobs:
       - name: Run tests
         run: ${{ inputs.command }}
         working-directory: ${{ inputs.working-directory }}
+
+  # A dummy job that you can mark as a required check instead of each individual test
+  test-suite:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Test suite
+    steps:
+      - run: echo Test suite completed


### PR DESCRIPTION
These dummy jobs allow repository admins to simply set a single required check, instead of each individual check. That's nearly impossible to maintain, given the exact matrix is determined externally and also differs per branch.

The two are separated because last time I tried I couldn't depend on a conditional test, which existing-database is.