### PR TITLE
limit test runs to 60 minutes

### DIFF
--- a/.github/workflows/foreman_plugin.yml
+++ b/.github/workflows/foreman_plugin.yml
@@ -50,6 +50,11 @@ on:
         required: false
         default: ''
         type: string
+      timeout_minutes:
+        description: timout for the test jobs in minutes
+        required: false
+        default: 60
+        type: number
 
 env:
   RAILS_ENV: test
@@ -78,6 +83,7 @@ jobs:
     name: "${{ matrix.task }} - Foreman ${{ inputs.foreman_version }} with Ruby ${{ matrix.ruby }} and Node ${{ matrix.node }} on PostgreSQL ${{ matrix.postgresql }}"
     needs: setup_matrix
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     services:
       postgres:
         image: '${{ inputs.postgresql_container }}:${{ matrix.postgresql }}'
@@ -198,6 +204,7 @@ jobs:
     if: ${{ inputs.test_existing_database }}
     needs: setup_matrix
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     services:
       postgres:
         image: '${{ inputs.postgresql_container }}:${{ matrix.postgresql }}'

--- a/.github/workflows/foreman_plugin_js.yml
+++ b/.github/workflows/foreman_plugin_js.yml
@@ -41,6 +41,11 @@ on:
         required: false
         default: ''
         type: string
+      timeout_minutes:
+        description: timout for the test jobs in minutes
+        required: false
+        default: 60
+        type: number
 
 jobs:
   setup_matrix:
@@ -62,6 +67,7 @@ jobs:
     name: "Foreman ${{ inputs.foreman_version }} Ruby ${{ matrix.ruby }} and Node ${{ matrix.node }}"
     needs: setup_matrix
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
the default is 360 minutes (6h), which is super long and when jobs take
that long they usually are broken and hang for some weird reason, let's
kill those earlier and free up resources
