### PR TITLE
Use rubygems-await to wait for the gem to be available

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -33,3 +33,7 @@ jobs:
         run: gem push *.gem
         env:
           GEM_HOST_API_KEY: '${{ secrets.api_key }}'
+      - name: Wait for release to propagate
+        run: |
+          gem install rubygems-await
+          gem await *.gem


### PR DESCRIPTION
I have not yet tested this. In https://github.com/voxpupuli/gem-workflow-test I have, but there we used the latest Ruby. The latest rubygems-await requires Ruby 3.2 so it may be needed. #64 does that change that so perhaps it's a dependency of this.