### PR TITLE
Release on the latest stable Ruby version

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -10,7 +10,7 @@ on:
         type: 'string'
       ruby_version:
         description: 'Ruby version used to build'
-        default: '3.1'
+        default: 'ruby'
         type: 'string'
     secrets:
       api_key:


### PR DESCRIPTION
This avoids the need to update it all the time. Our workflow only uses basic Ruby and Rubygems commands so this should be safe.