### PR TITLE
Create reusable workflow for labelling PRs breaks-robottelo

### DIFF
--- a/.github/workflows/breaks-robottelo.yml
+++ b/.github/workflows/breaks-robottelo.yml
@@ -1,0 +1,23 @@
+name: Label a PR `breaks-robottelo` on appropriate comment
+on:
+  workflow_call:
+    inputs:
+      repo:
+        required: true
+        type: string
+      issue:
+        required: true
+        type: string
+    secrets:
+      GH_TOKEN:
+        required: true
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.event.comment.body == '/label breaks-robottelo'
+    steps:
+      - run: gh issue edit ${{ inputs.issue }} --add-label breaks-robottelo --repo ${{ inputs.repo }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -241,6 +241,28 @@ jobs:
       command: bundle exec rake test
 ```
 
+## breaks-robottelo labeller
+
+A workflow that, on adding a `/label breaks-robottelo` comment to a PR, adds a label `breaks-robottelo` to that PR.
+
+```yaml
+name: Label a PR `breaks-robottelo` on appropriate comment
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  breaks-robottelo:
+    uses: theforeman/actions/.github/workflows/breaks-robottelo.yml@v0
+    permissions:
+      pull-requests: write
+    with:
+      repo: ${{ github.repository }}
+      issue: ${{ github.event.issue.number }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+
 ## Gem release (DEPRECATED)
 
 This action is deprecated in favour of using Trusted Publishing with [voxpupuli/ruby-release](https://github.com/voxpupuli/ruby-release).


### PR DESCRIPTION
This is a reusable workflow that, on adding a `/label breaks-robottelo` comment to a PR, adds a label `breaks-robottelo` to that PR.

### Reason:
In my team, we've identified a problem: often, a PR breaks our tests, be it an API change, UI change, or whatever not-that-important change that gives QE hard time in the process of finding a failure, identifying a change, investigating whether the change was intended and fixing the test in Robottelo. Most often, it seems, this is caused by WebUI locators changes.
We have proposed this solution: there will be an optional label for foreman and foreman-plugin repos that developers should set when they expect some change will break tests, especially WebUI. The QEs then should prefer to look at these PRs to change the tests before they get broken.