### PR TITLE
Revert "build apidoc during tests"

### DIFF
--- a/.github/workflows/foreman_plugin.yml
+++ b/.github/workflows/foreman_plugin.yml
@@ -98,7 +98,7 @@ jobs:
         node: ${{ fromJson(needs.setup_matrix.outputs.matrix).node }}
         postgresql: ${{ fromJson(needs.setup_matrix.outputs.matrix).postgresql }}
         task:
-          - 'test:${{ inputs.plugin }} apipie:cache'
+          - 'test:${{ inputs.plugin }}'
           - 'db:seed'
           - 'plugin:assets:precompile[${{ inputs.plugin }}] RAILS_ENV=production DATABASE_URL=nulldb://nohost'
         include: ${{ fromJson(needs.setup_matrix.outputs.matrix).include }}
@@ -182,13 +182,7 @@ jobs:
         run: cp -f db/schema.rb.nulldb db/schema.rb
         if: ${{ contains(matrix.task, 'nulldb') }}
       - name: Run rake ${{ matrix.task }}
-        run: ${{ contains(matrix.task, 'apipie') && 'APIPIE_RECORD=examples FOREMAN_APIPIE_LANGS=en' || '' }} bundle exec rake ${{ matrix.task }}
-      - name: Archive apidoc
-        uses: actions/upload-artifact@v4
-        if: contains(matrix.task, 'apipie')
-        with:
-          name: apidoc-${{ env.ARTIFACT_SUFFIX }}
-          path: public/apipie-cache/apidoc/
+        run: bundle exec rake ${{ matrix.task }}
       - name: Upload logs
         uses: actions/upload-artifact@v4
         if: ${{ failure() && contains(matrix.task, 'test') }}


### PR DESCRIPTION
Reverts theforeman/actions#71

This breaks plugins that extend core APIs, as apipie seems not to be able to load the api docs in the right order