### PR TITLE
allow installing additional packages for rubocop

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -24,6 +24,11 @@ on:
           fi
         required: false
         type: string
+      additional_packages:
+        description: String of additional packages that should be installed
+        default: ''
+        required: false
+        type: string
 
 jobs:
   rubocop:
@@ -31,6 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: install additional packages
+        if: ${{ inputs.additional_packages != '' }}
+        run: sudo apt-get install -y ${{ inputs.additional_packages }}
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
this is useful when a gem has dependencies that require os packages installed and `bundle install` fails without those