### PR TITLE
Update package list before installing packages

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: install additional packages
         if: ${{ inputs.additional_packages != '' }}
-        run: sudo apt-get install -y ${{ inputs.additional_packages }}
+        run: sudo apt-get update && sudo apt-get install -y ${{ inputs.additional_packages }}
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This currently blocks actions which are using this rubocop workflow. They fail with:

Ign:2 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.8 Err:2 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.8
  404  Not Found [IP: 52.161.185.214 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/c/curl/libcurl4-openssl-dev_8.5.0-2ubuntu10.8_amd64.deb  404  Not Found [IP: 52.161.185.214 80] E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?